### PR TITLE
This change removes the phrase "Its code in the public domain" from t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,4 +148,4 @@ f7fab000-f7fac000 rw-p 00003000 08:01 2726661      /home/lys/Documents/elf/testc
 
 ## License
 
-**elfspirit** is open source software. Its code is in the public domain. See the `LICENSE` file for more details.
+**elfspirit** is open source software. See the `LICENSE` file for more details.


### PR DESCRIPTION
…he end of README.md.

The reason for this change is that this code is not in the public domain. Public domain
means that the code is not copyrighted and is not owned by anyone. This is not the case
here. The code is actually copyrighted by liyansong2018 and provided under the MIT open
source license.  The author should remove the public domain statement to ensure people
don't accidentally think no one owns the code.